### PR TITLE
Add #![no_std]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = [ ".gitignore", "TESTVECTORS" ]
 arrayref = "0.3.2"
 rust-crypto = "^0.2"
 rand = "^0.3"
-curve25519-dalek = "^0.1"
+curve25519-dalek = "^0.3"
 
 [dev-dependencies]
 rustc-serialize = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,20 @@ exclude = [ ".gitignore", "TESTVECTORS" ]
 
 
 [dependencies]
-arrayref = "0.3.2"
-rust-crypto = "^0.2"
-rand = "^0.3"
-curve25519-dalek = "^0.3"
+arrayref = "0.3.3"
+sha2 = "^0.4"
+
+[dependencies.curve25519-dalek]
+version = "^0.3"
+default-features = false
+
+[dependencies.rand]
+optional = true
+version = "^0.3"
 
 [dev-dependencies]
 rustc-serialize = "0.3"
+
+[features]
+default = ["std"]
+std = ["rand"]

--- a/src/ed25519.rs
+++ b/src/ed25519.rs
@@ -18,7 +18,7 @@ use crypto::sha2::Sha512;
 use rand::Rng;
 
 use curve25519_dalek::curve;
-use curve25519_dalek::curve::CompressedPoint;
+use curve25519_dalek::curve::CompressedEdwardsY;
 use curve25519_dalek::curve::ExtendedPoint;
 use curve25519_dalek::curve::ProjectivePoint;
 use curve25519_dalek::scalar::Scalar;
@@ -142,7 +142,7 @@ impl SecretKey {
         let hram_digest: Scalar;
         let r: ExtendedPoint;
         let s: Scalar;
-        let t: CompressedPoint;
+        let t: CompressedEdwardsY;
 
         let secret_key: &[u8; 32] = array_ref!(&self.0,  0, 32);
         let public_key: &[u8; 32] = array_ref!(&self.0, 32, 32);
@@ -182,11 +182,11 @@ impl SecretKey {
 
 /// An ed25519 public key.
 #[derive(Copy, Clone)]
-pub struct PublicKey(pub CompressedPoint);
+pub struct PublicKey(pub CompressedEdwardsY);
 
 impl Debug for PublicKey {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-        write!(f, "PublicKey( CompressedPoint( {:?} ))", self.0)
+        write!(f, "PublicKey( CompressedEdwardsY( {:?} ))", self.0)
     }
 }
 
@@ -202,7 +202,7 @@ impl PublicKey {
     /// # Warning
     ///
     /// The caller is responsible for ensuring that the bytes passed into this
-    /// method actually represent a `curve25519_dalek::curve::CompressedPoint`
+    /// method actually represent a `curve25519_dalek::curve::CompressedEdwardsY`
     /// and that said compressed point is actually a point on the curve.
     ///
     /// # Example
@@ -224,7 +224,7 @@ impl PublicKey {
     #[inline]
     #[allow(dead_code)]
     fn from_bytes(bytes: &[u8]) -> PublicKey {
-        PublicKey(CompressedPoint(*array_ref!(bytes, 0, 32)))
+        PublicKey(CompressedEdwardsY(*array_ref!(bytes, 0, 32)))
     }
 
     /// Convert this public key to its underlying extended twisted Edwards coordinate.
@@ -325,7 +325,7 @@ impl Keypair {
         }
 
         Keypair{
-            public: PublicKey(CompressedPoint(pk)),
+            public: PublicKey(CompressedEdwardsY(pk)),
             secret: SecretKey(sk),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,16 +58,22 @@
 //! assert!(verified);
 //! ```
 
+#![no_std]
 #![feature(rand)]
 #![allow(unused_features)]
 #![feature(test)]
 
 #[macro_use]
 extern crate arrayref;
-extern crate crypto;
+extern crate sha2;
 extern crate curve25519_dalek;
+
+#[cfg(feature = "std")]
 extern crate rand;
 
+#[cfg(test)]
+#[macro_use]
+extern crate std;
 #[cfg(test)]
 extern crate test;
 #[cfg(test)]


### PR DESCRIPTION
Use `::core` in lieu of `::std`, allowing this crate to be usable in `#![no_std]` environments.

Gates features that presently depend on ::std (presently just rand) behind a "std" cargo feature, which is enabled by default.

Switches to the `sha2` crate in lieu of `rust-crypto`: the `sha2` crate is part of an effort to break up `rust-crypto` from a monolithic library into a set of interoperable crates, but is otherwise mostly just `s/crypto:://`. The `sha2` crate already supports `#![no_std]` out of the box (unlike `rust-crypto`)