### PR TITLE
Add conditional compilation to allow use on stable

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,9 +59,9 @@
 //! ```
 
 #![no_std]
-#![feature(rand)]
+#![cfg_attr(std, feature(rand))]
 #![allow(unused_features)]
-#![feature(test)]
+#![cfg_attr(test, feature(test))]
 
 #[macro_use]
 extern crate arrayref;


### PR DESCRIPTION
Same as PR submitted on curve25519-dalek except also adds a `cfg_attr` on the "rand" feature. That should be changed to require the `rand` crate on crates.io.