### PR TITLE
Fix a small typo in the license url.

### DIFF
--- a/src/ed25519.rs
+++ b/src/ed25519.rs
@@ -3,7 +3,7 @@
 // To the extent possible under law, the authors have waived all copyright and
 // related or neighboring rights to curve25519-dalek, using the Creative
 // Commons "CC0" public domain dedication.  See
-// <http://creativecommons.org/publicdomain/zero/.0/> for full details.
+// <http://creativecommons.org/publicdomain/zero/1.0/> for full details.
 //
 // Authors:
 // - Isis Agora Lovecruft <isis@patternsinthevoid.net>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 // To the extent possible under law, the authors have waived all copyright and
 // related or neighboring rights to curve25519-dalek, using the Creative
 // Commons "CC0" public domain dedication.  See
-// <http://creativecommons.org/publicdomain/zero/.0/> for full details.
+// <http://creativecommons.org/publicdomain/zero/1.0/> for full details.
 //
 // Authors:
 // - Isis Agora Lovecruft <isis@patternsinthevoid.net>


### PR DESCRIPTION
This is a tiny typo fix. The Creative Commons links in the license headers for lib.rs and ed25519.rs both return a 404. They are just missing the "1" in "1.0."