### PR TITLE
Use a custom error type instead of &'static str.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,10 @@ optional = true
 version = "^0.6"
 optional = true
 
+[dependencies.failure]
+version = "^0.1.1"
+default-features = false
+
 [dev-dependencies]
 hex = "0.2"
 sha2 = "^0.6"
@@ -52,7 +56,7 @@ bincode = "^0.9"
 
 [features]
 default = ["std"]
-std = ["rand", "curve25519-dalek/std"]
+std = ["rand", "curve25519-dalek/std", "failure/std"]
 bench = []
 nightly = ["curve25519-dalek/nightly"]
 asm = ["sha2/asm"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ed25519-dalek"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Isis Lovecruft <isis@torproject.org>"]
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/src/ed25519.rs
+++ b/src/ed25519.rs
@@ -908,12 +908,7 @@ impl Display for FromBytesError {
     }
 }
 
-#[cfg(feature = "std")]
-impl ::std::error::Error for FromBytesError {
-    fn description(&self) -> &str {
-        "wrong length of bytes when constructing ed25519 object"
-    }
-}
+impl ::failure::Fail for FromBytesError { }
 
 #[inline(always)]
 fn check_bytes_len(bytes: &[u8], len: usize) -> Result<(), FromBytesError> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,9 +143,9 @@
 //! # extern crate ed25519_dalek;
 //! # use rand::{Rng, OsRng};
 //! # use sha2::Sha512;
-//! # use ed25519_dalek::{Keypair, Signature, PublicKey, SecretKey};
+//! # use ed25519_dalek::{Keypair, Signature, PublicKey, SecretKey, FromBytesError};
 //! # use ed25519_dalek::{PUBLIC_KEY_LENGTH, SECRET_KEY_LENGTH, KEYPAIR_LENGTH, SIGNATURE_LENGTH};
-//! # fn do_test() -> Result<(SecretKey, PublicKey, Keypair, Signature), &'static str> {
+//! # fn do_test() -> Result<(SecretKey, PublicKey, Keypair, Signature), FromBytesError> {
 //! # let mut cspring: OsRng = OsRng::new().unwrap();
 //! # let keypair_orig: Keypair = Keypair::generate::<Sha512>(&mut cspring);
 //! # let message: &[u8] = "This is a test of the tsunami alert system.".as_bytes();
@@ -267,7 +267,7 @@ extern crate subtle;
 #[cfg(feature = "std")]
 extern crate rand;
 
-#[cfg(test)]
+#[cfg(any(feature = "std", test))]
 #[macro_use]
 extern crate std;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -263,6 +263,7 @@ extern crate curve25519_dalek;
 extern crate generic_array;
 extern crate digest;
 extern crate subtle;
+extern crate failure;
 
 #[cfg(feature = "std")]
 extern crate rand;


### PR DESCRIPTION
Advantages of a custom error type:

- It can be more easily integrated into other error types by clients;
  they can implement From<FromBytesError> for their error types, or
  they can use a library like failure.
- It is a zero-sized type, which can enable some representational
  optimizations.
- It can be easier and more stable to test for.

However, this is a question here. By using a single `FromBytesError`, each
error loses the contextual information about what you were parsing from bytes.
We could instead use a custom error type for each function (`SignatureError`,
`PublicKeyError`, etc) if this contextual information seems valuable.